### PR TITLE
Interupped Clipping

### DIFF
--- a/src/AccessUnit.cpp
+++ b/src/AccessUnit.cpp
@@ -1,4 +1,3 @@
-#include "StdAfx.h"
 #include "AccessUnit.h"
 
 
@@ -10,7 +9,7 @@ AccessUnit::AccessUnit()
 {
 }
 
-AccessUnit::AccessUnit(const BYTE* sodb, unsigned int len)
+AccessUnit::AccessUnit(const uint8_t* sodb, unsigned int len)
 {
 	std::copy(sodb, sodb+len, std::back_inserter(sodb_));
 }
@@ -67,7 +66,7 @@ AccessUnit::~AccessUnit()
 
 }
 
-void AccessUnit::insert(const BYTE* sodb, unsigned int len)
+void AccessUnit::insert(const uint8_t* sodb, unsigned int len)
 {
 	sodb_.insert(sodb_.end(), &sodb[0], &sodb[len]);
 }

--- a/src/AccessUnit.h
+++ b/src/AccessUnit.h
@@ -6,12 +6,12 @@
 class AccessUnit
 {
 public:
-	typedef std::vector<BYTE> sodb_type; // string of data bits collection type
+	typedef std::vector<uint8_t> sodb_type; // string of data bits collection type
 	typedef sodb_type::iterator iterator;
 	typedef sodb_type::const_iterator const_iterator;
 public:
 	AccessUnit();
-	AccessUnit(const BYTE* sodb, unsigned int len);
+	AccessUnit(const uint8_t* sodb, unsigned int len);
 	AccessUnit(const AccessUnit& cp);
 	AccessUnit& operator=(const AccessUnit& rhs);
 	AccessUnit(AccessUnit&& cp) noexcept;
@@ -20,7 +20,7 @@ public:
 
 	void swap(AccessUnit& src);
 
-	void insert(const BYTE* sodb, unsigned int len);
+	void insert(const uint8_t* sodb, unsigned int len);
 
 	void clear();
 
@@ -32,7 +32,7 @@ public:
 	const_iterator begin() const { return sodb_.begin(); }
 	const_iterator end() const { return sodb_.end(); }
 
-	const BYTE* data() const { return sodb_.data(); };
+	const uint8_t* data() const { return sodb_.data(); };
 
 	bool isKey() const { return isKey_; }
 	void toogleKey() { isKey_ = isKey_ ? false : true; }
@@ -43,11 +43,11 @@ private:
 	bool        isKey_{false};
 
 public:
-	UINT64 pts_{0};  // units of 90 kHz clock
-	UINT64 dts_{0};  // units of 90 kHz clock
-	BYTE PTS[5]{};
-	BYTE DTS[5]{};
-	UINT16 PES_packet_length_{0};
+	uint64_t pts_{0};  // units of 90 kHz clock
+	uint64_t dts_{0};  // units of 90 kHz clock
+	uint8_t PTS[5]{};
+	uint8_t DTS[5]{};
+	uint16_t PES_packet_length_{0};
 };
 
 inline bool operator==(const AccessUnit& lhs, const AccessUnit& rhs)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,17 +17,17 @@ else()
 endif()
 
 if (CMAKE_VS_PLATFORM_NAME)
-    include_directories(../../mp2tp/libmp2t)
+    include_directories(../../../../lib/mp2tp/libmp2t)
     add_library(lcss::libmp2t STATIC IMPORTED)
     set_target_properties(lcss::libmp2t PROPERTIES
-                 IMPORTED_LOCATION ../../mp2tp/libmp2t/Release/libmp2t.lib
-                 IMPORTED_LOCATION_DEBUG ../../mp2tp/libmp2t/Debug/libmp2t.lib
+                 IMPORTED_LOCATION ../../../../lib/mp2tp/libmp2t/Release/libmp2t.lib
+                 IMPORTED_LOCATION_DEBUG ../../../../lib/mp2tp/libmp2t/Debug/libmp2t.lib
                  IMPORTED_CONFIGURATIONS "RELEASE;DEBUG")
-    include_directories(../../h264p/libh264p)
+    include_directories(../../../../lib/h264p/libh264p)
     add_library(ThetaStream::libh264p STATIC IMPORTED)
     set_target_properties(ThetaStream::libh264p PROPERTIES
-                 IMPORTED_LOCATION ../../h264p/libh264p/Release/libh264p.lib
-                 IMPORTED_LOCATION_DEBUG ../../h264p/libh264p/Debug/libh264p.lib
+                 IMPORTED_LOCATION ../../../../lib/h264p/libh264p/Release/libh264p.lib
+                 IMPORTED_LOCATION_DEBUG ../../../../lib/h264p/libh264p/Debug/libh264p.lib
                  IMPORTED_CONFIGURATIONS "RELEASE;DEBUG")
     add_compile_definitions(_ITERATOR_DEBUG_LEVEL=0)
 else ()

--- a/src/Clipper.cpp
+++ b/src/Clipper.cpp
@@ -1,0 +1,120 @@
+#include "Clipper.h"
+
+#include "CommandLineParser.h"
+#include "Mpeg2TsDecoder.h"
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#ifdef _WIN32
+#include <io.h>
+#include <Windows.h>
+#endif
+
+#include <cstdint>
+#include <fcntl.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <vector>
+#include <sstream>
+
+namespace fs = std::filesystem;
+
+namespace 
+{
+	std::shared_ptr<std::istream> openInputStream(const std::string& input)
+	{
+		using namespace std;
+		std::shared_ptr<std::istream> ifile;
+		if (input == "-")
+		{
+#ifdef _WIN32
+			_setmode(_fileno(stdin), _O_BINARY);
+#endif
+			ifile.reset(&cin, [](...) {});
+		}
+		else
+		{
+			ifstream* tsfile = new ifstream(input, ios::binary);
+			if (!tsfile->is_open())
+			{
+				std::stringstream msg;
+				msg << "Fail to open input file, " << input;
+				std::runtime_error ex(msg.str().c_str());
+				throw ex;
+			}
+			ifile.reset(tsfile);
+		}
+		return ifile;
+	}
+
+	void createOutputDir(const std::string& strDirname)
+	{
+		std::error_code errc{};
+		auto curdir = fs::current_path();
+		fs::path dirname(strDirname);
+		fs::path dirpath = curdir / dirname;
+		if (!fs::exists(dirpath))
+		{
+			if (!fs::create_directory(dirpath, errc))
+			{
+				std::stringstream msg;
+				msg << "Fail to create output directory, " << strDirname;
+				std::runtime_error ex(msg.str().c_str());
+				throw ex;
+			}
+		}
+	}
+}
+
+
+class ThetaStream::Clipper::Impl
+{
+public:
+	Impl(const ThetaStream::CommandLineParser& cmdline)
+		:_decoder(std::make_unique<Mpeg2TsDecoder>(cmdline))
+	{
+		_ifile = openInputStream(cmdline.filename());
+		createOutputDir(cmdline.outputDirectory());
+		_memblockSize = cmdline.filename() == "-" ? 7 * 188 : 49 * 188;
+		_memblock.resize(_memblockSize);
+	}
+
+public:
+	bool _run{ true };
+	std::unique_ptr<Mpeg2TsDecoder> _decoder;
+	std::shared_ptr<std::istream> _ifile;
+	std::vector<uint8_t> _memblock{};
+	size_t _memblockSize{};
+};
+
+ThetaStream::Clipper::Clipper(const ThetaStream::CommandLineParser& cmdline)
+	:_pimpl(std::make_unique<ThetaStream::Clipper::Impl>(cmdline))
+{
+}
+
+ThetaStream::Clipper::~Clipper()
+{
+	stop();
+}
+
+void ThetaStream::Clipper::operator()()
+{
+	while (_pimpl->_ifile->good())
+	{
+		_pimpl->_ifile->read((char*)_pimpl->_memblock.data(), _pimpl->_memblockSize);
+		const std::streamsize read = _pimpl->_ifile->gcount();
+		if (read > 0)
+		{
+			_pimpl->_decoder->parse(_pimpl->_memblock.data(), (unsigned)read);
+		}
+	}
+}
+
+void ThetaStream::Clipper::stop()
+{
+	_pimpl->_run = false;
+}

--- a/src/Clipper.h
+++ b/src/Clipper.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <memory>
+
+namespace ThetaStream
+{
+	class CommandLineParser;
+}
+
+namespace ThetaStream
+{
+	class Clipper
+	{
+	public:
+		Clipper(const ThetaStream::CommandLineParser& cmdline);
+		~Clipper();
+
+		void operator()();
+
+		void stop();
+
+	private:
+		class Impl;
+		std::unique_ptr<Impl> _pimpl;
+
+	};
+}
+

--- a/src/Monitor.cpp
+++ b/src/Monitor.cpp
@@ -1,0 +1,73 @@
+#include "Monitor.h"
+
+#include "Clipper.h"
+
+#include <chrono>
+#include <thread>
+
+namespace ThetaStream
+{
+	class Monitor::Impl
+	{
+	public:
+		Impl(ThetaStream::Clipper& clipper, int duration)
+			:_clipper(clipper)
+			, _duration(duration)
+		{
+
+		}
+
+		~Impl()
+		{
+
+		}
+
+	public:
+		ThetaStream::Clipper& _clipper;
+		int _duration{};
+		int _count{};
+		bool _run{ true };
+	};
+}
+
+ThetaStream::Monitor::Monitor(ThetaStream::Clipper& clipper, int duration)
+	:_pimpl(std::make_unique<ThetaStream::Monitor::Impl>(clipper, duration))
+{
+
+}
+
+ThetaStream::Monitor::~Monitor()
+{
+	stop();
+}
+
+void ThetaStream::Monitor::operator() ()
+{
+	while (_pimpl->_run)
+	{
+		int bytes = _pimpl->_clipper.bytes();
+		if (bytes == 0)
+		{
+			_pimpl->_count++;
+			if (_pimpl->_count == _pimpl->_duration)
+			{
+				_pimpl->_clipper.closeFile();
+				_pimpl->_count = 0;
+			}
+		}
+		else if (bytes < 0)
+		{
+			stop();
+		}
+		else
+		{
+			_pimpl->_count = 0;
+		}
+		std::this_thread::sleep_for(std::chrono::seconds(1));
+	}
+}
+
+void ThetaStream::Monitor::stop()
+{
+	_pimpl->_run = false;
+}

--- a/src/Monitor.h
+++ b/src/Monitor.h
@@ -4,29 +4,24 @@
 
 namespace ThetaStream
 {
-	class CommandLineParser;
+	class Clipper;
 }
 
 namespace ThetaStream
 {
-	class Clipper
+	class Monitor
 	{
 	public:
-		Clipper(const ThetaStream::CommandLineParser& cmdline);
-		~Clipper();
+		Monitor(Clipper& clipper, int duration);
+		~Monitor();
 
-		void operator()();
+		void operator () ();
 
 		void stop();
-
-		void closeFile();
-
-		int bytes();
 
 	private:
 		class Impl;
 		std::unique_ptr<Impl> _pimpl;
-
 	};
 }
 

--- a/src/Mpeg2TsDecoder.cpp
+++ b/src/Mpeg2TsDecoder.cpp
@@ -7,12 +7,14 @@
 #endif // !_WIN32
 
 #include <cstdint>
+#include <filesystem>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <stdlib.h>
 
 using namespace std;
+namespace fs = std::filesystem;
 
 #ifdef _WIN32
 #define sprintf sprintf_s
@@ -103,11 +105,30 @@ namespace
 #endif
 		return ret;
 	}
+
+	void createOutputDir(const std::string& strDirname)
+	{
+		std::error_code errc{};
+		auto curdir = fs::current_path();
+		fs::path dirname(strDirname);
+		fs::path dirpath = curdir / dirname;
+		if (!fs::exists(dirpath))
+		{
+			if (!fs::create_directory(dirpath, errc))
+			{
+				std::stringstream msg;
+				msg << "Fail to create output directory, " << strDirname;
+				std::runtime_error ex(msg.str().c_str());
+				throw ex;
+			}
+		}
+	}
 }
 
 Mpeg2TsDecoder::Mpeg2TsDecoder(const ThetaStream::CommandLineParser& cmdline)
 	: _cmdline(cmdline)
 {
+	createOutputDir(cmdline.outputDirectory());
 	createClippedFile();
 }
 

--- a/src/Mpeg2TsDecoder.cpp
+++ b/src/Mpeg2TsDecoder.cpp
@@ -276,6 +276,11 @@ void Mpeg2TsDecoder::writePacket(lcss::TransportPacket& pckt)
 		return;
 	}
 
+	if (!_ofile.is_open())
+	{
+		createClippedFile();
+	}
+
 	if ( (timeExpired() || _labelChanged) && _videoDecoder.hasKeyFrame())
 	{
 		createClippedFile();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 
 #include "CommandLineParser.h"
 #include "Clipper.h"
+#include "Monitor.h"
 
 #ifdef _WIN32
 #include <io.h>
@@ -15,6 +16,7 @@
 #ifdef _WIN32
 BOOL CtrlHandler(DWORD fdwCtrlType);
 ThetaStream::Clipper* pClipper;
+ThetaStream::Monitor* pMonitor;
 #endif
 
 using namespace ThetaStream;
@@ -36,10 +38,14 @@ int main(int argc, char* argv[])
 #endif
 		Clipper clipper(cmdline);
 		pClipper = &clipper;
+		Monitor monitor(clipper, cmdline.length());
+		pMonitor = &monitor;
 
 		thread clipperThread(&Clipper::operator(), &clipper);
+		thread monitorThread(&Monitor::operator(), &monitor);
 
 		clipperThread.join();
+		monitorThread.join();
 	}
 	catch (std::exception & ex)
 	{
@@ -67,6 +73,7 @@ BOOL CtrlHandler(DWORD fdwCtrlType)
 	case CTRL_SHUTDOWN_EVENT:
 	case CTRL_LOGOFF_EVENT:
 		pClipper->stop();
+		pMonitor->stop();
 		std::cerr << "Closing down, please wait" << std::endl;
 		Sleep(1000);
 		return TRUE;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,52 +1,31 @@
 // mp2tclip.cpp : This file contains the 'main' function. Program execution begins and ends there.
 //
 
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-
 #include "CommandLineParser.h"
-#include "Mpeg2TsDecoder.h"
+#include "Clipper.h"
 
 #ifdef _WIN32
 #include <io.h>
 #include <Windows.h>
 #endif
-#include <cstdint>
-#include <fcntl.h>
-#include <filesystem>
-#include <fstream>
+
 #include <iostream>
-#include <memory>
-#include <vector>
-#include <sstream>
-
-
-using namespace ThetaStream;
-using namespace std;
-namespace fs = std::filesystem;
+#include <thread>
 
 #ifdef _WIN32
 BOOL CtrlHandler(DWORD fdwCtrlType);
-Mpeg2TsDecoder* pDecoder;
+ThetaStream::Clipper* pClipper;
 #endif
-std::shared_ptr<istream> openInputStream(const std::string& input);
-void createOutputDir(const std::string& dirpath);
+
+using namespace ThetaStream;
+using namespace std;
 
 int main(int argc, char* argv[])
 {
-	std::vector<uint8_t> memblock{};
 	try
 	{
 		CommandLineParser cmdline;
 		cmdline.parse(argc, argv, "Mp2tClip");
-
-		shared_ptr<istream> ifile = openInputStream(cmdline.filename());
-		
-		createOutputDir(cmdline.outputDirectory());
-
-		size_t N = cmdline.filename() == "-" ? 7 * 188 : 49 * 188;
-		memblock.resize(N);
 
 #ifdef _WIN32
 		if (!SetConsoleCtrlHandler((PHANDLER_ROUTINE)CtrlHandler, TRUE)) {
@@ -55,18 +34,11 @@ int main(int argc, char* argv[])
 			return err;
 		}
 #endif
+		Clipper clipper(cmdline);
 
-		Mpeg2TsDecoder decoder(cmdline);
-		pDecoder = &decoder;
-		while (ifile->good())
-		{
-			ifile->read((char*)memblock.data(), N);
-			const streamsize read = ifile->gcount();
-			if (read > 0)
-			{
-				decoder.parse(memblock.data(), (unsigned)read);
-			}
-		}
+		thread clipperThread(&Clipper::operator(), &clipper);
+
+		clipperThread.join();
 	}
 	catch (std::exception & ex)
 	{
@@ -93,7 +65,7 @@ BOOL CtrlHandler(DWORD fdwCtrlType)
 	case CTRL_BREAK_EVENT:
 	case CTRL_SHUTDOWN_EVENT:
 	case CTRL_LOGOFF_EVENT:
-		pDecoder->close();
+		pClipper->stop();
 		std::cerr << "Closing down, please wait" << std::endl;
 		Sleep(1000);
 		return TRUE;
@@ -103,46 +75,4 @@ BOOL CtrlHandler(DWORD fdwCtrlType)
 }
 #endif
 
-std::shared_ptr<std::istream> openInputStream(const std::string& input)
-{
-	std::shared_ptr<std::istream> ifile;
-	if (input == "-")
-	{
-#ifdef _WIN32
-		_setmode(_fileno(stdin), _O_BINARY);
-#endif
-		ifile.reset(&cin, [](...) {});
-	}
-	else
-	{
-		ifstream* tsfile = new ifstream(input, ios::binary);
-		if (!tsfile->is_open())
-		{
-			std::stringstream msg;
-			msg << "Fail to open input file, " << input;
-			std::runtime_error ex(msg.str().c_str());
-			throw ex;
-		}
-		ifile.reset(tsfile);
-	}
-	return ifile;
-}
-
-void createOutputDir(const std::string& strDirname)
-{
-	std::error_code errc{};
-	auto curdir = fs::current_path();
-	fs::path dirname(strDirname);
-	fs::path dirpath = curdir / dirname;
-	if (!fs::exists(dirpath))
-	{
-		if (!fs::create_directory(dirpath, errc))
-		{
-			std::stringstream msg;
-			msg << "Fail to create output directory, " << strDirname;
-			std::runtime_error ex(msg.str().c_str());
-			throw ex;
-		}
-	}
-}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@ int main(int argc, char* argv[])
 		}
 #endif
 		Clipper clipper(cmdline);
+		pClipper = &clipper;
 
 		thread clipperThread(&Clipper::operator(), &clipper);
 


### PR DESCRIPTION
Mp2tClip application clips files based on duration or when classification level changes.  If a stream stops before meeting these conditions, Mp2tClip application will keep the clipped file open and preventing ClipPub application to process the file.  In this release, Mp2tClip will close the clipped file after specific amount of time, which is specified in the -d parameter.  This behavior will allow ClipPub application to process the clipped file.  The Mp2tClip instance can accept a new stream after the timeout period.