### PR TITLE
19 fail to clip on duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 /build
 /sample/clipped
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required (VERSION 3.21)
 
 project(Mp2tClip
-	VERSION 1.2.0
+	VERSION 1.2.1
 	DESCRIPTION "A command line program that decompose (clips) a MPEG-2 TS file/stream into multiple files."
 	LANGUAGES CXX
 )

--- a/Mp2tClipImpl/CMakeLists.txt
+++ b/Mp2tClipImpl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21.0)
 
 project (
     Mp2tClipImpl
-    VERSION 1.2.0
+    VERSION 1.2.1
     DESCRIPTION "The core code for the Mp2tClip application."
     LANGUAGES CXX
 )
@@ -47,7 +47,7 @@ target_sources(Mp2tClipImpl
     src/VideoDecoder.h
 )
 
-set_property(TARGET Mp2tClipImpl PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_target_properties(Mp2tClipImpl PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_compile_features(Mp2tClipImpl PUBLIC cxx_std_17)
 

--- a/Mp2tClipImpl/src/Mpeg2TsDecoder.cpp
+++ b/Mp2tClipImpl/src/Mpeg2TsDecoder.cpp
@@ -99,12 +99,13 @@ namespace
         char newfname[512]{};
         char* bname = basename((char*)path.c_str());
         char fname[128]{};
-        int i = 0;
-        char c = bname[i];
-        while (c != '.')
+        size_t len = strlen(bname);
+        for (int i = 0; i < len; i++)
         {
-            fname[i] = c;
-            c = bname[i++];
+            char c = bname[i];
+            if (c == '.')
+                break;
+            fname[i] = bname[i];
         }
 
         string ts = create_timestamp();
@@ -295,17 +296,19 @@ void Mpeg2TsDecoder::updateClock(const lcss::TransportPacket& pckt)
             adf->getPCR(pcr);
 
             temp.setTime(pcr);
-
             auto pcrTime = _pcrClock.time();
-            _pcrClock.setTime(pcr);
+            _pcrClock.setTime(pcr); 
             auto newPcrTime = temp.time();
 
             if (pcrTime > newPcrTime)
             {
                 std::cerr << "Discontinual timpstamp. Create Clip." << std::endl;
                 onCreateClipWithoutKeyFrame();
+                _duration = std::numeric_limits<uint64_t>::max();
+                uint8_t nullTime[6]{};
+                _pcrClock.setTime(nullTime);
                 return;
-            }
+            }            
 
             if (_duration == std::numeric_limits<uint64_t>::max() && _offset < _pcrClock.time())
             {
@@ -314,10 +317,13 @@ void Mpeg2TsDecoder::updateClock(const lcss::TransportPacket& pckt)
         }
     }
 
-    timeExpired();
+    if (timeExpired())
+    {
+        onCreateClip();
+    }
 }
 
-bool Mpeg2TsDecoder::timeExpired()
+bool Mpeg2TsDecoder::timeExpired() const
 {
     if (_duration == std::numeric_limits<uint64_t>::max())
     {
@@ -327,10 +333,10 @@ bool Mpeg2TsDecoder::timeExpired()
     uint64_t pcr = _pcrClock.time();
     long diff = _duration - pcr;
     long absDiff = abs(diff);
+
     if (absDiff < 27'000'000 // Within one second, create a clip
         || _duration < pcr ) // If the pcr > duration, we lost PCR timestamp.
-    {
-        onCreateClip();
+    {        
         return true;
     }
     return false;
@@ -338,6 +344,7 @@ bool Mpeg2TsDecoder::timeExpired()
 
 void Mpeg2TsDecoder::onCreateClip()
 {
+    _duration = _pcrClock.time() + _length;
     if (_cmdline.keyFrame())
     {
         onCreateClipWithKeyFrame();
@@ -350,9 +357,6 @@ void Mpeg2TsDecoder::onCreateClip()
 
 void Mpeg2TsDecoder::onCreateClipWithKeyFrame()
 {
-    std::vector<AccessUnit> startAUs;
-    bool isKey{ false };
-
     if (!_ofile.is_open())
     {
         createClippedFile();
@@ -374,7 +378,7 @@ void Mpeg2TsDecoder::onCreateClipWithKeyFrame()
     {
         _ofile.write((const char*)au.data(), au.length());
     }
-    _duration = _pcrClock.time() + _length;
+
     _segment.clear();
 }
 
@@ -390,8 +394,6 @@ void Mpeg2TsDecoder::onCreateClipWithoutKeyFrame()
     {
         _ofile.write((const char*)p.data(), p.length());
     }
-    _duration = _pcrClock.time() + _length;
-    _segment.clear();
 }
 
 void Mpeg2TsDecoder::onPayloadUnitStart(lcss::TransportPacket& pckt)

--- a/Mp2tClipImpl/src/Mpeg2TsDecoder.cpp
+++ b/Mp2tClipImpl/src/Mpeg2TsDecoder.cpp
@@ -338,8 +338,6 @@ bool Mpeg2TsDecoder::timeExpired()
 
 void Mpeg2TsDecoder::onCreateClip()
 {
-    _duration = _pcrClock.time() + _length;
-
     if (_cmdline.keyFrame())
     {
         onCreateClipWithKeyFrame();
@@ -376,6 +374,7 @@ void Mpeg2TsDecoder::onCreateClipWithKeyFrame()
     {
         _ofile.write((const char*)au.data(), au.length());
     }
+    _duration = _pcrClock.time() + _length;
     _segment.clear();
 }
 
@@ -391,6 +390,7 @@ void Mpeg2TsDecoder::onCreateClipWithoutKeyFrame()
     {
         _ofile.write((const char*)p.data(), p.length());
     }
+    _duration = _pcrClock.time() + _length;
     _segment.clear();
 }
 

--- a/Mp2tClipImpl/src/Mpeg2TsDecoder.cpp
+++ b/Mp2tClipImpl/src/Mpeg2TsDecoder.cpp
@@ -23,7 +23,7 @@ namespace fs = std::filesystem;
 #define _MAX_PATH 512
 #endif
 
-const uint64_t RESOLUTION = 27'000'000; // 27MHz
+const uint64_t RESOLUTION = 27'000'000; // 27 MHz
 
 namespace
 {
@@ -153,8 +153,8 @@ private:
 
 Mpeg2TsDecoder::Mpeg2TsDecoder(const ThetaStream::CommandLineParser& cmdline)
     : _cmdline(cmdline)
-    , _length((cmdline.length() + 2)* RESOLUTION)
-    , _offset(cmdline.offset()* RESOLUTION)
+    , _length((cmdline.length() + 1) * RESOLUTION)
+    , _offset(cmdline.offset() * RESOLUTION)
 {
     createOutputDir(cmdline.outputDirectory());
 }
@@ -326,8 +326,9 @@ bool Mpeg2TsDecoder::timeExpired()
 
     uint64_t pcr = _pcrClock.time();
     long diff = _duration - pcr;
-    diff = abs(diff);
-    if (diff < 27'000'000)
+    long absDiff = abs(diff);
+    if (absDiff < 27'000'000 // Within one second, create a clip
+        || _duration < pcr ) // If the pcr > duration, we lost PCR timestamp.
     {
         onCreateClip();
         return true;
@@ -337,6 +338,8 @@ bool Mpeg2TsDecoder::timeExpired()
 
 void Mpeg2TsDecoder::onCreateClip()
 {
+    _duration = _pcrClock.time() + _length;
+
     if (_cmdline.keyFrame())
     {
         onCreateClipWithKeyFrame();
@@ -373,7 +376,6 @@ void Mpeg2TsDecoder::onCreateClipWithKeyFrame()
     {
         _ofile.write((const char*)au.data(), au.length());
     }
-    _duration = _pcrClock.time() + _length;
     _segment.clear();
 }
 
@@ -389,8 +391,6 @@ void Mpeg2TsDecoder::onCreateClipWithoutKeyFrame()
     {
         _ofile.write((const char*)p.data(), p.length());
     }
-
-    _duration = _pcrClock.time() + _length;
     _segment.clear();
 }
 

--- a/Mp2tClipImpl/src/Mpeg2TsDecoder.h
+++ b/Mp2tClipImpl/src/Mpeg2TsDecoder.h
@@ -32,7 +32,7 @@ public:
 private:
     void createClippedFile();
     void updateClock(const lcss::TransportPacket& pckt);
-    bool timeExpired();
+    bool timeExpired() const;
     void onCreateClip();
     void onCreateClipWithKeyFrame();
     void onCreateClipWithoutKeyFrame();

--- a/Mp2tClipImpl/src/PCRClock.cpp
+++ b/Mp2tClipImpl/src/PCRClock.cpp
@@ -30,6 +30,11 @@ void PCRClock::setTime(uint8_t* time)
 	memcpy(_time, time, 6);
 }
 
+void PCRClock::getTime(uint8_t* buf)
+{
+	memcpy(buf, _time, 6);
+}
+
 double PCRClock::timeInSeconds() const
 {
 	return (double)(time() / RESOLUTION);

--- a/Mp2tClipImpl/src/PCRClock.h
+++ b/Mp2tClipImpl/src/PCRClock.h
@@ -11,6 +11,8 @@ public:
 
 public:
 	void setTime(uint8_t* time);
+	void getTime(uint8_t* buf);
+	
 	double timeInSeconds() const;
 	uint64_t time() const;
 	uint64_t baseTime() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,7 @@ using namespace std;
 
 void banner()
 {
-	std::cerr << "Mp2tClip: MPEG-2 TS Clipper Application v1.2.0" << std::endl;
+	std::cerr << "Mp2tClip: MPEG-2 TS Clipper Application v1.2.1" << std::endl;
 	std::cerr << "Copyright (c) 2025 ThetaStream Consulting, jimcavoy@thetastream.com" << std::endl;
 }
 


### PR DESCRIPTION
Handle the case if we lose TS packets containing PCR timestamps.  If the PCR timestamp exceeds the duration, create a clip.