### PR TITLE
Migrated VS 2026

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required (VERSION 3.21)
 
 project(Mp2tClip
-	VERSION 1.2.1
+	VERSION 1.2.2
 	DESCRIPTION "A command line program that decompose (clips) a MPEG-2 TS file/stream into multiple files."
 	LANGUAGES CXX
 )
@@ -24,7 +24,7 @@ target_link_libraries(Mp2tClip PRIVATE Mp2tClipImpl)
 # dependers
 target_compile_features(
     Mp2tClip
-    PUBLIC cxx_std_17
+    PUBLIC cxx_std_20
 )
 
 # Install targets

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,7 +3,7 @@
     "configurePresets": [
         {
             "name": "windows-base",
-            "generator": "Visual Studio 17 2022",
+            "generator": "Visual Studio 18 2026",
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl.exe",

--- a/Mp2tClipImpl/CMakeLists.txt
+++ b/Mp2tClipImpl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21.0)
 
 project (
     Mp2tClipImpl
-    VERSION 1.2.1
+    VERSION 1.2.2
     DESCRIPTION "The core code for the Mp2tClip application."
     LANGUAGES CXX
 )
@@ -49,7 +49,7 @@ target_sources(Mp2tClipImpl
 
 set_target_properties(Mp2tClipImpl PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-target_compile_features(Mp2tClipImpl PUBLIC cxx_std_17)
+target_compile_features(Mp2tClipImpl PUBLIC cxx_std_20)
 
 if(WIN32)
     target_link_libraries(Mp2tClipImpl lcss::mp2tp thetastream::h264p wsock32 ws2_32 Boost::interprocess)

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "4f8fe05871555c1798dbcb1957d0d595e94f7b57",
+    "baseline": "3895230f38e498525f2560a281223d12066fa74a",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
On Windows, migrated to Visual Studio 2026.
Updated vcpkg baseline.
Moved to C++20.