### PR TITLE
Bump Version

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,8 +28,8 @@ using namespace std;
 
 void banner()
 {
-	std::cerr << "Mp2tClip: MPEG-2 TS Clipper Application v1.2.1" << std::endl;
-	std::cerr << "Copyright (c) 2025 ThetaStream Consulting, jimcavoy@thetastream.com" << std::endl;
+	std::cerr << "Mp2tClip: MPEG-2 TS Clipper Application v1.2.2" << std::endl;
+	std::cerr << "Copyright (c) 2026 ThetaStream Consulting, jimcavoy@thetastream.com" << std::endl;
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
Bump version to 1.2.2.
Update copyright year to 2026.
Only the string for the banner has been modified.